### PR TITLE
fix: refactor `gather_licenses_info` aspect to traverse all attributes

### DIFF
--- a/rules/gather_licenses_info.bzl
+++ b/rules/gather_licenses_info.bzl
@@ -24,7 +24,7 @@ load(":types.bzl", "types")
 # MARK: - Debug
 
 # Debugging verbosity
-_VERBOSITY = 0
+_VERBOSITY = 1
 
 def _debug(loglevel, msg):
     if _VERBOSITY > loglevel:
@@ -48,8 +48,12 @@ def _print_debug(dbg):
 
 _ATTRS_TO_TRAVERSE = [
     "applicable_licenses",
+    "base",  # cc_interface_library
     "deps",
+    "interface_roots",  # simple_cc_shared_library
     "implementation_deps",
+    "interface_deps",  # cc_interface_library
+    "roots",  # simple_cc_shared_library
     "srcs",
 ]
 
@@ -60,20 +64,26 @@ def _license_list_to_labels(license_list):
         licenses = license_list
     return [li.rule for li in licenses]
 
+def _get_transitive_licenses_for_dep(dbg, dep, licenses, trans):
+    _add_debug(dbg, lambda: "  depends on {}".format(dep.label))
+    if LicenseInfo in dep:
+        license = dep[LicenseInfo]
+        _add_debug(dbg, lambda: "    with license {}".format(license.rule))
+        licenses.append(license)
+    if LicensesInfo in dep:
+        license_list = dep[LicensesInfo].licenses
+        if license_list:
+            _add_debug(dbg, lambda: "    transitively depends on: {}".format(
+                _license_list_to_labels(license_list),
+            ))
+            trans.append(license_list)
+
 def _get_transitive_licenses(dbg, deps, licenses, trans):
-    for dep in deps:
-        _add_debug(dbg, lambda: "  depends on {}".format(dep.label))
-        if LicenseInfo in dep:
-            license = dep[LicenseInfo]
-            _add_debug(dbg, lambda: "    with license {}".format(license.rule))
-            licenses.append(license)
-        if LicensesInfo in dep:
-            license_list = dep[LicensesInfo].licenses
-            if license_list:
-                _add_debug(dbg, lambda: "    transitively depends on: {}".format(
-                    _license_list_to_labels(license_list),
-                ))
-                trans.append(license_list)
+    if types.is_list(deps):
+        for dep in deps:
+            _get_transitive_licenses_for_dep(dbg, dep, licenses, trans)
+    else:
+        _get_transitive_licenses_for_dep(dbg, deps, licenses, trans)
 
 def _gather_licenses_info_impl(target, ctx):
     licenses = []

--- a/rules/gather_licenses_info.bzl
+++ b/rules/gather_licenses_info.bzl
@@ -24,7 +24,7 @@ load(":types.bzl", "types")
 # MARK: - Debug
 
 # Debugging verbosity
-_VERBOSITY = 1
+_VERBOSITY = 0
 
 def _debug(loglevel, msg):
     if _VERBOSITY > loglevel:
@@ -46,16 +46,10 @@ def _print_debug(dbg):
 
 # MARK: - gather_licenses_info
 
-_ATTRS_TO_TRAVERSE = [
-    "applicable_licenses",
-    "base",  # cc_interface_library
-    "deps",
-    "interface_roots",  # simple_cc_shared_library
-    "implementation_deps",
-    "interface_deps",  # cc_interface_library
-    "roots",  # simple_cc_shared_library
-    "srcs",
-]
+_TARGET_TYPE = "Target"
+
+def _is_target(val):
+    return type(val) == _TARGET_TYPE
 
 def _license_list_to_labels(license_list):
     if types.is_depset(license_list):
@@ -78,29 +72,31 @@ def _get_transitive_licenses_for_dep(dbg, dep, licenses, trans):
             ))
             trans.append(license_list)
 
-def _get_transitive_licenses(dbg, deps, licenses, trans):
-    if types.is_list(deps):
-        for dep in deps:
-            _get_transitive_licenses_for_dep(dbg, dep, licenses, trans)
+def _get_transitive_licenses_for_item(dbg, val, licenses, trans):
+    if not _is_target(val):
+        return
+    _get_transitive_licenses_for_dep(dbg, val, licenses, trans)
+
+def _get_transitive_licenses(dbg, val, licenses, trans):
+    if types.is_list(val):
+        for li in val:
+            _get_transitive_licenses_for_item(dbg, li, licenses, trans)
     else:
-        _get_transitive_licenses_for_dep(dbg, deps, licenses, trans)
+        _get_transitive_licenses_for_item(dbg, val, licenses, trans)
 
 def _gather_licenses_info_impl(target, ctx):
     licenses = []
     trans = []
     dbg = []
-    _add_debug(dbg, lambda: "Gathering license info from {}".format(target))
-    for attr in _ATTRS_TO_TRAVERSE:
-        if hasattr(ctx.rule.attr, attr):
-            deps = getattr(ctx.rule.attr, attr)
-            _get_transitive_licenses(dbg, deps, licenses, trans)
-    _print_debug(dbg)
+    for attr in dir(ctx.rule.attr):
+        val = getattr(ctx.rule.attr, attr)
+        _get_transitive_licenses(dbg, val, licenses, trans)
     return [LicensesInfo(licenses = depset(tuple(licenses), transitive = trans))]
 
 gather_licenses_info = aspect(
     doc = """Collects LicenseInfo providers into a single LicensesInfo provider.""",
     implementation = _gather_licenses_info_impl,
-    attr_aspects = _ATTRS_TO_TRAVERSE,
+    attr_aspects = ["*"],
     apply_to_generating_rules = True,
 )
 


### PR DESCRIPTION
Refactor `gather_licenses_info` aspect to traverse all attributes. This allows us to find all dependencies and their respective licenses.

Related to https://github.com/revealtech/theia/issues/2740.
